### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -382,7 +382,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@6a58db7e0d21ca03e6c44877909e80e45217eed2 # v2.6.0
+        uses: docker/setup-buildx-action@ecf95283f03858871ff00b787d79c419715afc34 # v2.7.0
 
       # TODO validate no changes between github.event.pull_request.head.sha and the actual current sha (representing the hypothetical merge)
 
@@ -445,7 +445,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request'
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@6a58db7e0d21ca03e6c44877909e80e45217eed2 # v2.6.0
+        uses: docker/setup-buildx-action@ecf95283f03858871ff00b787d79c419715afc34 # v2.7.0
 
       - name: Download artifact
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: returntocorp/semgrep:1.26.0@sha256:8d7fba41e0ddcd60bf7933aabaa575dc0c36ed4e79760d91859a4ba9915abe6e
+      image: returntocorp/semgrep:1.27.0@sha256:7026020ebb6c1aa477431a2ba550df3ae4d080822e391d03bb816eeac700a36b
 
     steps:
       - name: Check out repo
@@ -34,6 +34,6 @@ jobs:
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@83f0fe6c4988d98a455712a27f0255212bba9bd4 # v2.3.6
+        uses: github/codeql-action/upload-sarif@6c089f53dd51dc3fc7e599c3cb5356453a52ca9e # v2.20.0
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
- chore(deps): update docker/build-push-action action to v4.1.0
- chore(deps): update actions/checkout action to v3.5.3
- chore(deps): update returntocorp/semgrep docker tag to v1.26.0
- chore(deps): update rust:1.70.0 docker digest to 508253a
- chore(deps): update docker/build-push-action action to v4.1.1
- chore(deps): update dependency semantic-release to ^21.0.5
- chore(deps): update docker/metadata-action action to v4.6.0
- chore(deps): update alpine docker tag to v3.18.2
- chore(deps): update returntocorp/semgrep docker tag to v1.27.0
- chore(deps): update docker/setup-buildx-action action to v2.7.0
- chore(deps): update github/codeql-action action to v2.20.0
