### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
@@ -83,7 +83,7 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
           fetch-depth: 0
@@ -161,7 +161,7 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
@@ -205,7 +205,7 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
@@ -247,7 +247,7 @@ jobs:
     if: fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
@@ -359,7 +359,7 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
@@ -403,7 +403,7 @@ jobs:
       APPLICATION_NAME: PLACEHOLDER # overridden in step 'Set application name', this is merely to satisfy the linter
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
           fetch-depth: 0

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,8 +14,8 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
           token: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -55,7 +55,7 @@ jobs:
       fromJSON(needs.repo-has-container.outputs.has_container) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
           fetch-depth: 2

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -42,8 +42,8 @@ jobs:
     if: |
       fromJSON(needs.repo-has-container.outputs.has_container) == true
     steps:
-      - name: Check out repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -22,29 +22,19 @@ jobs:
       image: returntocorp/semgrep:1.66.0@sha256:2fd35fa409f209e0fea0c2d72cf1e5b801a607959a93b13d04822bb3b6a9dfe4
 
     steps:
-      - name: Check out repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
       - name: Run semgrep
-        shell: bash
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
         run: |
           semgrep ci --sarif --output=semgrep.sarif
 
-      - name: Fixup semgrep.sarif's startColumn==0 and/or endColumn==0
-        shell: bash
-        run: |
-          jq '.' semgrep.sarif > normalized.sarif
-          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.startColumn==0) | .startColumn)' normalized.sarif > fixed_start_column.sarif
-          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.endColumn==0) | .endColumn)' fixed_start_column.sarif > fixed_start_end_column.sarif
-
-          diff normalized.sarif fixed_start_end_column.sarif || true
-
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
         uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3.24.9
         with:
-          sarif_file: fixed_start_end_column.sarif
+          sarif_file: semgrep.sarif

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -27,7 +27,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,14 @@
 {
-    "rust-analyzer.runnables.extraEnv": {
-        "RUST_LOG": "DEBUG,advent_of_code_2021=TRACE"
-    },
-    "rust-analyzer.debug.openDebugPane": true,
+    "debug.internalConsoleOptions": "openOnSessionStart",
+    "prettier.configPath": "./.prettierrc.cjs",
     "rust-analyzer.debug.engineSettings": {
         "lldb": {
             "internalConsoleOptions": "openOnSessionStart",
             "terminal": "console"
         }
     },
-    "debug.internalConsoleOptions": "openOnSessionStart"
+    "rust-analyzer.debug.openDebugPane": true,
+    "rust-analyzer.runnables.extraEnv": {
+        "RUST_LOG": "DEBUG,advent_of_code_2021=TRACE"
+    }
 }


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.61.1**
- **chore(deps): update dorny/paths-filter action to v3.0.1**
- **chore(deps): update github/codeql-action action to v3.24.2**
- **chore(deps): update github/codeql-action action to v3.24.3**
- **chore(deps): update rust:1.76.0 docker digest to a71cd88**
- **chore: explicitely set prettierrc's path**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.62.0**
- **chore(deps): update rui314/setup-mold digest to 910273f**
- **chore(deps): update github/codeql-action action to v3.24.5**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/download-artifact action to v4.1.3**
- **chore(deps): update docker/setup-buildx-action action to v3.1.0**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.15.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.63.0**
- **chore: align title**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.15.1**
- **chore(deps): update npm to >=10.5.0**
- **chore(deps): update github/codeql-action action to v3.24.6**
- **chore(deps): update actions/cache action to v4.0.1**
- **chore(deps): update rui314/setup-mold digest to c9803d2**
- **chore(deps): update actions/download-artifact action to v4.1.4**
- **chore(deps): update dorny/paths-filter action to v3.0.2**
- **chore(deps): lock file maintenance**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 77b7c17**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.64.0**
- **chore(deps): update docker/build-push-action action to v5.2.0**
- **chore(deps): update rui314/setup-mold digest to 65ebd6e**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.65.0**
- **chore(deps): update rust:1.76.0 docker digest to 969ca54**
- **chore(deps): update actions/checkout action to v4.1.2**
- **chore(deps): update rust:1.76.0 docker digest to 2d1630a**
- **chore(deps): update github/codeql-action action to v3.24.7**
- **chore(deps): update rust:1.76.0 docker digest to af1e799**
- **chore(deps): update rust:1.76.0 docker digest to d36f9d8**
- **chore(deps): update docker/login-action action to v3.1.0**
- **chore(deps): update docker/build-push-action action to v5.3.0**
- **chore(deps): update docker/setup-buildx-action action to v3.2.0**
- **fix(deps): update rust crate color-eyre to 0.6.3**
- **chore(deps): update dependency @semantic-release/github to v10**
- **chore(deps): update dependency semantic-release to v23.0.3**
- **chore(deps): update dependency semantic-release to v23.0.4**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency @semantic-release/commit-analyzer to v12**
- **chore(deps): update dependency semantic-release to v23.0.5**
- **chore(deps): update github/codeql-action action to v3.24.8**
- **chore(deps): update actions/cache action to v4.0.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.66.0**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.16.0**
- **fix: don't set shell, not needed in semgrep container**
- **fix: separate scan and fixup, as the scan container doesn't have bash / jq anymore**
- **fix: only upload sarif file itself**
- **fix: set unpack folder, not filepath**
- **chore: checkout to satisfy the codeql tool**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.16.1**
- **chore(deps): update rust to v1.77.0**
- **chore(deps): update github/codeql-action action to v3.24.9**
- **chore: rename semgrep job to make it register with semgrep**
- **chore: use semgrep action, not container**
- **chore(deps): update returntocorp/semgrep-action digest to 713efdd**
- **chore: back to container, the action is outdated**
- **chore: add category**
- **chore: semgrep 1 job**
- **chore: fix filename**
