### PR TITLE
update from upstream

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -142,7 +142,7 @@ branches:
           - context: "codecov/project"
             app_id: 254
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: false
+      enforce_admins: null
       # Prevent merge commits from being pushed to matching branches
       required_linear_history: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,11 @@ version = "0.0.0-development"
 edition = "2021"
 rust-version = "1.79.0"
 authors = ["Kristof Mattei"]
-license-file = "LICENSE"
 description = "Advent of Code 2021"
-repository = "https://github.com/kristof-mattei/advent-of-code-2021"
-keywords = ["playground"]
+license-file = "LICENSE"
 categories = ["playground"]
-
+keywords = ["playground"]
+repository = "https://github.com/kristof-mattei/advent-of-code-2021"
 [profile.dev]
 debug = true
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Advent of code 2021
+# Advent of Code 2021

--- a/update-name.sh
+++ b/update-name.sh
@@ -1,31 +1,25 @@
 #!/bin/bash
 
-
 NEW_NAME=$1
 
 FILTERED_NAME=$(echo "${NEW_NAME}" | sed -e "s/[a-z0-9-]//g")
 
-
 echo "New name = ${NEW_NAME}"
-
 
 if [[ ${#FILTERED_NAME} != 0 ]]; then
     echo "Name only allows [a-z0-9-], found ${FILTERED_NAME} (length = ${#FILTERED_NAME})"
     exit 1
 fi
 
-
 NEW_NAME_WITH_UNDERSCORE=$(echo "${NEW_NAME}" | sed -e "s/-/_/g")
 
 echo "New name with underscore = ${NEW_NAME_WITH_UNDERSCORE}"
 
-
-P1="rust-end-to-end-"
-OLD_NAME="${P1}application"
+PART_NAME="rust-"
+OLD_NAME="${PART_NAME}seed"
 OLD_NAME_WITH_UNDERSCORE=$(echo "${OLD_NAME}" | sed -e "s/-/_/g")
 
 echo ${OLD_NAME_WITH_UNDERSCORE}
-
 
 rg --hidden --files-with-matches ${OLD_NAME} | xargs -i sed -i "s/${OLD_NAME}/${NEW_NAME}/g" {}
 rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE}


### PR DESCRIPTION
- **chore(deps): update rust:1.79.0 docker digest to 2c454db**
- **chore(deps): update rui314/setup-mold digest to 65685f4**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.76.0**
- **chore(deps): update docker/build-push-action action to v6**
- **chore(deps): update docker/build-push-action digest to 94f8f8c**
- **chore(deps): update docker/build-push-action action to v6.0.1**
- **chore(deps): update docker/build-push-action action to v6.0.2**
- **chore(deps): update dependency node to v20.15.0**
- **chore(deps): update alpine docker tag to v3.20.1**
- **chore(deps): update docker/build-push-action action to v6.1.0**
- **chore(deps): update dependency @semantic-release/release-notes-generator to v14.0.1**
- **chore: change name**
- **chore(deps): lock file maintenance**
- **chore: separate the name so the rename script doesn't update it**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.77.0**
- **chore(deps): update docker/build-push-action action to v6.2.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.78.0**
- **chore(deps): update github/codeql-action action to v3.25.11**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency @semantic-release/github to v10.0.7**
- **chore(deps): update rust:1.79.0 docker digest to 4c4f16b**
- **chore(deps): update rust:1.79.0 docker digest to 4c45f61**
- **chore(deps): update docker/build-push-action action to v6.3.0**
- **chore: enforce_admins should be null if you want to disable it...**
