### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,18 +118,26 @@ jobs:
         working-directory: /tmp
         run: |
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
-          wget "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}"
-
-          tar -xvf "./${archive}"
-
-          rm "./${archive}"
-
-          mv ./cargo-binstall ~/.cargo/bin/
+          wget \
+            --output-document=- \
+            --timeout=10 \
+            --waitretry=3 \
+            --retry-connrefused \
+            --progress=dot:mega \
+            "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}" \
+            | tar \
+                --directory=${HOME}/.cargo/bin/ \
+                --strip-components=1 \
+                --no-overwrite-dir \
+                --extract \
+                --verbose \
+                --gunzip \
+                --file=-
 
       - name: Install cocogitto to get the next version number
         shell: bash
         run: |
-          cargo binstall --no-confirm cocogitto --target x86_64-unknown-linux-musl --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ bin }" --pkg-fmt tgz
+          cargo binstall --no-confirm cocogitto
 
       - name: Calculate next version
         shell: bash
@@ -309,28 +317,33 @@ jobs:
         working-directory: /tmp
         run: |
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
-          wget "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}"
+          wget \
+            --output-document=- \
+            --timeout=10 \
+            --waitretry=3 \
+            --retry-connrefused \
+            --progress=dot:mega \
+            "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}" \
+            | tar \
+                --directory=${HOME}/.cargo/bin/ \
+                --strip-components=1 \
+                --no-overwrite-dir \
+                --extract \
+                --verbose \
+                --gunzip \
+                --file=-
 
-          tar -xvf "./${archive}"
-
-          rm "./${archive}"
-
-          mv ./cargo-binstall ~/.cargo/bin/
-
-      - name: Install nextest, custom test runner, with native support for junit
+      - name: Install nextest, custom test runner, with native support for junit and grcov
         shell: bash
         run: |
-          cargo binstall --no-confirm cargo-nextest;
-
-      - name: Install grcov
-        shell: bash
-        run: |
-          cargo binstall --no-confirm grcov --pkg-url "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.bz2" --pkg-fmt tbz2 --bin-dir "{ bin }";
+          cargo binstall --no-confirm cargo-nextest grcov
 
       - name: Build with instrumentation support
         shell: bash
         env:
-          RUSTFLAGS: "${{ env.RUSTFLAGS }} --allow=warnings -C instrument-coverage"
+          RUSTFLAGS: "${{ env.RUSTFLAGS }} --allow=warnings -Cinstrument-coverage"
+          # build-* ones are not parsed by grcov
+          LLVM_PROFILE_FILE: "profiling/build-%p-%m.profraw"
         run: |
           cargo build --all-targets --all-features --workspace --verbose
 
@@ -338,7 +351,7 @@ jobs:
         shell: bash
         id: tests
         env:
-          RUSTFLAGS: "${{ env.RUSTFLAGS }} --allow=warnings -C instrument-coverage"
+          RUSTFLAGS: "${{ env.RUSTFLAGS }} --allow=warnings -Cinstrument-coverage"
           LLVM_PROFILE_FILE: "profiling/profile-%p-%m.profraw"
         run: |
           cargo nextest run --profile ci --no-fail-fast --all-targets --all-features --workspace
@@ -354,7 +367,7 @@ jobs:
       - name: Run grcov
         shell: bash
         run: |
-          grcov $(find profiling -name "profile-*.profraw" -print) --source-dir . --binary-path ./target/debug/ --output-type lcov --branch --ignore-not-existing --llvm --keep-only "src/**" --keep-only "tests/**" --output-path ./reports/lcov.info
+          grcov $(find . -name "profile-*.profraw" -print) --source-dir . --binary-path ./target/debug/ --output-type lcov --branch --ignore-not-existing --llvm --keep-only "src/**" --output-path ./reports/lcov.info
 
       - name: Upload coverage results (to Codecov.io)
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
@@ -383,7 +396,7 @@ jobs:
           # we don't know which subsection it belongs in GitHub
           # so we explicitly fail this one
           # which will fail All Done
-          exit 1;
+          exit 1
 
   cargo-clippy-and-report:
     name: Cargo clippy (and report)

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -55,18 +55,26 @@ jobs:
         working-directory: /tmp
         run: |
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
-          wget "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}"
-
-          tar -xvf "./${archive}"
-
-          rm "./${archive}"
-
-          mv ./cargo-binstall ~/.cargo/bin/
+          wget \
+            --output-document=- \
+            --timeout=10 \
+            --waitretry=3 \
+            --retry-connrefused \
+            --progress=dot:mega \
+            "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}" \
+            | tar \
+                --directory=${HOME}/.cargo/bin/ \
+                --strip-components=1 \
+                --no-overwrite-dir \
+                --extract \
+                --verbose \
+                --gunzip \
+                --file=-
 
       - name: Install cocogitto to get the next version number
         shell: bash
         run: |
-          cargo binstall --no-confirm cocogitto --target x86_64-unknown-linux-musl --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ bin }" --pkg-fmt tgz
+          cargo binstall --no-confirm cocogitto
 
       - name: Check the commits
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,18 +71,26 @@ jobs:
         working-directory: /tmp
         run: |
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
-          wget "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}"
-
-          tar -xvf "./${archive}"
-
-          rm "./${archive}"
-
-          mv ./cargo-binstall ~/.cargo/bin/
+          wget \
+            --output-document=- \
+            --timeout=10 \
+            --waitretry=3 \
+            --retry-connrefused \
+            --progress=dot:mega \
+            "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}" \
+            | tar \
+                --directory=${HOME}/.cargo/bin/ \
+                --strip-components=1 \
+                --no-overwrite-dir \
+                --extract \
+                --verbose \
+                --gunzip \
+                --file=-
 
       - name: Install cocogitto to get the next version number
         shell: bash
         run: |
-          cargo binstall --no-confirm cocogitto --target x86_64-unknown-linux-musl --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ bin }" --pkg-fmt tgz
+          cargo binstall --no-confirm cocogitto
 
       - name: Bump
         shell: bash

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -65,18 +65,26 @@ jobs:
         working-directory: /tmp
         run: |
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
-          wget "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}"
-
-          tar -xvf "./${archive}"
-
-          rm "./${archive}"
-
-          mv ./cargo-binstall ~/.cargo/bin/
+          wget \
+            --output-document=- \
+            --timeout=10 \
+            --waitretry=3 \
+            --retry-connrefused \
+            --progress=dot:mega \
+            "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/${archive}" \
+            | tar \
+                --directory=${HOME}/.cargo/bin/ \
+                --strip-components=1 \
+                --no-overwrite-dir \
+                --extract \
+                --verbose \
+                --gunzip \
+                --file=-
 
       - name: Install cocogitto to get the next version number
         shell: bash
         run: |
-          cargo binstall --no-confirm cocogitto --target x86_64-unknown-linux-musl --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ bin }" --pkg-fmt tgz
+          cargo binstall --no-confirm cocogitto
 
       - name: Bump
         shell: bash

--- a/build.sh
+++ b/build.sh
@@ -1,29 +1,38 @@
 #!/usr/bin/env bash
 
 # sane defaults
-compiler="gcc"
-# static linking
-flags="-Clink-self-contained=yes -Clinker=rust-lld"
+c_compiler="gcc"
+cpp_compiler="g++"
 
-# mind the space between the [ and "
-if [[ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]]; then
-    case $TARGET in
-        x86_64-unknown-linux-musl)
-            compiler="i686-linux-gnu-gcc"
-            ;;
-        aarch64-unknown-linux-musl)
-            compiler="aarch64-linux-gnu-gcc"
-            ;;
-        *)
-            echo "INVALID CONFIGURATION"
-            exit 1
-            ;;
-    esac
-fi
+rust_flags="-Clink-self-contained=yes -Clinker=rust-lld"
+
+case $TARGET in
+    x86_64-unknown-linux-*)
+        c_compiler="x86_64-linux-gnu-gcc-12"
+        cpp_compiler="x86_64-linux-gnu-g++-12"
+        ;;
+    aarch64-unknown-linux-*)
+        c_compiler="aarch64-linux-gnu-gcc"
+        cpp_compiler="aarch64-linux-gnu-g++"
+        ;;
+    *)
+        echo "INVALID CONFIGURATION"
+        exit 1
+        ;;
+esac
 
 # replace - with _ in the Rust target
 target_lower=${TARGET//-/_}
-cc_var=CC_${target_lower}
-declare -x "${cc_var}=${compiler}"
 
-RUSTFLAGS=$flags cargo $@
+target_upper=${target_lower^^}
+
+cc_var=CC_${target_lower}
+declare -x "${cc_var}=${c_compiler}"
+
+cxx_var=CXX_${target_lower}
+declare -x "${cxx_var}=${cpp_compiler}"
+
+cargo_target_linker_var=CARGO_TARGET_${target_upper}_LINKER
+declare -x "${cargo_target_linker_var}=${c_compiler}"
+
+RUSTFLAGS=$rust_flags cargo $@

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,30 +1,26 @@
 #!/usr/bin/env bash
 
 dpkg_add_arch() {
-    dpkg --add-architecture $1
+    # are we cross compiling?
+    if ! dpkg-architecture -eq "$1"; then
+        dpkg --add-architecture $1
+    fi
     apt-get update
     apt-get --no-install-recommends install --yes \
-        gcc-$2-linux-gnu
+        binutils-$2-linux-gnu \
+        gcc-$2-linux-gnu \
+        g++-$2-linux-gnu
 }
 
-# mind the space between the [ and "
-if [[ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]]; then
-    case $TARGET in
-        x86_64-unknown-linux-musl)
-            dpkg_add_arch "amd64" "i686"
-
-            apt-get --no-install-recommends install --yes \
-                gcc-12-multilib-i686-linux-gnu
-            ;;
-        aarch64-unknown-linux-musl)
-            dpkg_add_arch "arm64" "aarch64"
-
-            apt-get --no-install-recommends install --yes \
-                libc6-dev-arm64-cross
-            ;;
-        *)
-            echo "INVALID CONFIGURATION"
-            exit 1
-            ;;
-    esac
-fi
+case $TARGET in
+    x86_64-unknown-linux-*)
+        dpkg_add_arch "amd64" "x86-64"
+        ;;
+    aarch64-unknown-linux-*)
+        dpkg_add_arch "arm64" "aarch64"
+        ;;
+    *)
+        echo "INVALID CONFIGURATION"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
- **chore: i686 is 32-bit, we need 64-bit**
- **chore: remove need for build & targetplatform in scripts**
- **chore(deps): update rui314/setup-mold digest to 67424c1**
- **chore: more precise coverage, don't include test/****
- **chore: make wget more robust**
- **chore: remove customization, packages now work oob with binstall**
